### PR TITLE
HandGrabSphereController: In run(), initialize aera_us to 100ms to match AERA

### DIFF
--- a/controllers/aera_hand_controller_protobuf/hand_grab_sphere_controller.cpp
+++ b/controllers/aera_hand_controller_protobuf/hand_grab_sphere_controller.cpp
@@ -114,7 +114,8 @@ void HandGrabSphereController::init() {
 }
 
 void HandGrabSphereController::run() {
-  int aera_us = 0;
+  // AERA sends the first command at 100ms.
+  int aera_us = 100'000;
 #ifdef DEBUG
   diagnostic_mode_ = true;
 #endif // DEBUG
@@ -147,12 +148,12 @@ void HandGrabSphereController::run() {
 
     double h_position = getAngularPosition(joint_1_sensor_->getValue());
 
-    if (aera_us == 1700 * 1000 + 40000) {
+    if (aera_us == 1800 * 1000 + 40000) {
       //reset
       init();
     }
-    // Don't send the state at time 0, but wait for the initial position.
-    if (aera_us > 0 && aera_us % 100'000 == 0) {
+    // Don't send the state on the first pass, but wait to arrive at the initial position.
+    if (aera_us > 100'000 && aera_us % 100'000 == 0) {
       const double* c_translation = cube_->getField("translation")->getSFVec3f();
       const double* s_translation = sphere_->getField("translation")->getSFVec3f();
       double c_position = getPosition(c_translation);


### PR DESCRIPTION
In hand-grab-sphere-learn, when `run()` sends the state where the hand is holding s for the first time, `aera_us` is at 300'000 . But the fact in AERA is at 400ms:

    (fact (mk.val h holding [s]) 0s:400ms:0us 0s:500ms:0us)
     
This gives me confusion during debugging. This pull request updates run() to offset `aera_us` by 100'000 . Now, the fact times match `aera_us` Also, `run()` calls `init()` in frame 1800ms which is the next frame after the grab failure (which makes sense to me).