### PR TITLE
Fix checking joint_base_to_jaw_2_sensor_ if the gripper is closed

### DIFF
--- a/controllers/aera_hand_controller_protobuf/hand_grab_sphere_controller.cpp
+++ b/controllers/aera_hand_controller_protobuf/hand_grab_sphere_controller.cpp
@@ -161,7 +161,7 @@ void HandGrabSphereController::run() {
 
       communication_id_t holding_id = -1;
       if (fabs(joint_base_to_jaw_1_sensor_->getValue() - jaw_closed_) < 0.0005 &&
-        fabs(joint_base_to_jaw_2_sensor_->getValue() - jaw_closed_)) {
+          fabs(joint_base_to_jaw_2_sensor_->getValue() - jaw_closed_) < 0.0005) {
         // The gripper is in the closed position. Check if an object is at the hand position with elevated Z.
         std::cout << "Hand Position: " << h_position << std::endl;
         std::cout << "Cube Position: " << c_position << std::endl;
@@ -295,7 +295,7 @@ void HandGrabSphereController::handleDataMsg(std::vector<tcp_io_device::MsgData>
     else if (id_name == "move")
     {
       target_h_position_ = it->getData<double>()[0];
-      std::cout << "Moving arm to " << target_h_position_ << std::endl;
+      std::cout << "Moving arm by " << target_h_position_ << std::endl;
       state_ = MOVE_ARM;
     }
   }


### PR DESCRIPTION
In run, we check if the gripper is closed:

    if (fabs(joint_base_to_jaw_1_sensor_->getValue() - jaw_closed_) < 0.0005 &&
        fabs(joint_base_to_jaw_2_sensor_->getValue() - jaw_closed_))

There is a typo. We also need to check if the expression with `joint_base_to_jaw_2_sensor_` is `< 0.0005`. 

(Currently, the expression `fabs(joint_base_to_jaw_2_sensor_->getValue() - jaw_closed_)` is some non-zero number which is cast to a boolean and is always true, so it basically doesn't affect the condition. The condition is really only checking the position of `joint_base_to_jaw_1_sensor_` . This is why the controller was doing what it's supposed to do, but we should still fix the condition.)

We also sneak in a small correction in the message for the move command. The move parameter is a delta, not a target position. So we change "Moving arm to" to "Moving arm by".