### PR TITLE
In the run loop, don't divide aera_us by robot_time_step_

### DIFF
--- a/controllers/hand_grab_sphere_NED_1D_controller/hand_grab_sphere_NED_1D_controller.cpp
+++ b/controllers/hand_grab_sphere_NED_1D_controller/hand_grab_sphere_NED_1D_controller.cpp
@@ -112,11 +112,11 @@ void HandGrabSphereController::initAfterFailedRelease() {
 
 void HandGrabSphereController::run() {
   // AERA sends the first command at 100ms.
-  int aera_us = 100'000 / robot_time_step_;
+  int aera_us = 100'000;
 #ifdef DEBUG
   diagnostic_mode_ = true;
 #endif // DEBUG
-  int receive_deadline = aera_us + 65000 / robot_time_step_;
+  int receive_deadline = aera_us + 65000;
   std::unique_ptr<tcp_io_device::TCPMessage> pending_msg;
   while (robot_->step(robot_time_step_) != -1) {
     if (!aera_started_) {
@@ -150,7 +150,7 @@ void HandGrabSphereController::run() {
     double h_position = getAngularPosition(joint_1_sensor_->getValue());
 
     // Don't send the state on the first pass, but wait to arrive at the initial position.
-    if (aera_us > 100'000 / robot_time_step_ && (aera_us % (int)(100'000 / robot_time_step_)) == 0) {
+    if (aera_us > 100'000 && aera_us % 100'000 == 0) {
       const double* c_translation = cube_->getField("translation")->getSFVec3f();
       const double* s_translation = sphere_->getField("translation")->getSFVec3f();
       double c_position = getPosition(c_translation);
@@ -196,11 +196,11 @@ void HandGrabSphereController::run() {
       }
       sendDataMessage(msg_data);
 
-      receive_deadline = aera_us + 65000 / robot_time_step_;
+      receive_deadline = aera_us + 65'000;
     }
     executeCommand();
-    int next_aera_us = aera_us + robot_time_step_ * 100 / robot_time_step_;
-    if (diagnostic_mode_ && state_ != IDLE && (next_aera_us % (int)(100'000 / robot_time_step_) == 0)) {
+    int next_aera_us = aera_us + robot_time_step_ * 100;
+    if (diagnostic_mode_ && state_ != IDLE && next_aera_us % 100'000 == 0) {
       // In the next interation, we would send the state, but the robot is still executing a command.
       // In diagnistic mode, don't advance aera_us but wait for IDLE until we send the state.
     }

--- a/controllers/hand_grab_sphere_UR_3D_controller/hand_grab_sphere_UR_3D_controller.cpp
+++ b/controllers/hand_grab_sphere_UR_3D_controller/hand_grab_sphere_UR_3D_controller.cpp
@@ -188,11 +188,11 @@ void UR3eController::init() {
 
 void UR3eController::run() {
 
-  int aera_us = 100'000 / robot_time_step_;
+  int aera_us = 100'000;
 #ifdef DEBUG
   diagnostic_mode_ = true;
 #endif // DEBUG
-  int receive_deadline = aera_us + 65'000 / robot_time_step_;
+  int receive_deadline = aera_us + 65'000;
   std::unique_ptr<tcp_io_device::TCPMessage> pending_msg;
   while (robot_->step(robot_time_step_) != -1) {
     running_time_steps_ += robot_time_step_;
@@ -232,7 +232,7 @@ void UR3eController::run() {
       pending_msg = NULL;
     }
     // Don't send the state on the first pass, but wait to arrive at the initial position.
-    if (aera_us > 100'000 / robot_time_step_ && (aera_us % (int)(100'000 / robot_time_step_)) == 0) {
+    if (aera_us > 100'000 && aera_us % 100'000 == 0) {
 
       const double* hand_pos_array = gps_sensor_->getValues();
       hand_xyz_pos_ = getRoundedXYZPosition(hand_pos_array);
@@ -392,12 +392,12 @@ void UR3eController::run() {
       //   std::cout << msg_data[i] << std::endl;
       // }
       measurement_state_ = NONE;
-      receive_deadline = aera_us + 65'000 / robot_time_step_;
+      receive_deadline = aera_us + 65'000;
     }
 
     executeCommand();
-    int next_aera_us = aera_us + robot_time_step_ * 100 / robot_time_step_;
-    if (diagnostic_mode_ && state_ != IDLE && (next_aera_us % (int)(100'000 / robot_time_step_) == 0)) {
+    int next_aera_us = aera_us + robot_time_step_ * 100;
+    if (diagnostic_mode_ && state_ != IDLE && next_aera_us % 100'000 == 0) {
       // In the next interation, we would send the state, but the robot is still executing a command.
       // In diagnistic mode, don't advance aera_us but wait for IDLE until we send the state.
     }


### PR DESCRIPTION
In loop in the controller run() method, `aera_us` is supposed to track the timestamp in AERA. But it is currently divided by `robot_time_step_` (which is 10). This means that when Webots transmits the state, aera_us doesn't match the timestamp on the facts received by AERA.

Note that aera_us is not actually sent with the data, but for debugging we may change the Webots controller to print aera_us to the console. Making the value match the timestamp on the AERA facts (shown in the Visualizer) makes debugging easier.